### PR TITLE
Fix job/company-create return flow and dashboard edit/back redirects

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -159,17 +159,16 @@ body {
 }
 
 .footer {
-  position: fixed;
-  left: 0;
-  bottom: 0;
+  /* Make footer participate in normal document flow so it doesn't overlap content */
+  position: static;
   width: 100%;
   background: #ffffff;
   border-top: 1px solid #E2E8F0;
   text-align: center;
   padding: 1rem 0;
-  font-size: 1 rem;
+  margin-top: 2rem; /* space between content and footer */
+  font-size: 1rem;
   color: #718096;
-  z-index: 100;
 }
 .footer-content {
 	max-width: 1000px;

--- a/app/controllers/companies_controller.rb
+++ b/app/controllers/companies_controller.rb
@@ -17,7 +17,13 @@ class CompaniesController < ApplicationController
   def create
     @company = Company.new(company_params)
     if @company.save
-      redirect_to companies_path, notice: 'Company created successfully'
+      # If the company was created from the jobs new flow, return to the
+      # job creation page so the user can select the new company and finish.
+      if params[:return_to] == 'jobs_new' || (request.referer || '').include?('/jobs/new')
+        redirect_to new_job_path, notice: 'Company created successfully'
+      else
+        redirect_to companies_path, notice: 'Company created successfully'
+      end
     else
       render :new, status: :unprocessable_entity
     end

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -3,6 +3,10 @@ class DashboardController < ApplicationController
 
   def index
     @jobs = current_user.jobs.includes(:company)
+    if params[:q].present?
+      q = "%#{params[:q].downcase}%"
+      @jobs = @jobs.joins(:company).where('LOWER(jobs.title) LIKE :q OR LOWER(companies.name) LIKE :q', q: q)
+    end
   end
 
   def personal_info

--- a/app/controllers/jobs_controller.rb
+++ b/app/controllers/jobs_controller.rb
@@ -59,7 +59,9 @@ class JobsController < ApplicationController
 
     @job = current_user.jobs.new(job_params)
     if @job.save
-      redirect_to jobs_path, notice: 'Job created'
+      # After creating a job, take the user to their dashboard so they see the
+      # newly created entry in context.
+      redirect_to dashboard_path, notice: 'Job created'
     else
       render :new, status: :unprocessable_entity
     end
@@ -81,7 +83,13 @@ class JobsController < ApplicationController
     end
 
     if @job.update(job_params)
-      redirect_to jobs_path, notice: 'Job updated'
+      # If the edit started from the dashboard, send the user back there so
+      # they see the updated entry in the table. Fall back to jobs_path.
+      if params[:from] == 'dashboard' || (request.referer || '').include?('/dashboard')
+        redirect_to dashboard_path, notice: 'Job updated'
+      else
+        redirect_to jobs_path, notice: 'Job updated'
+      end
     else
       render :edit, status: :unprocessable_entity
     end
@@ -89,7 +97,12 @@ class JobsController < ApplicationController
 
   def destroy
     @job.destroy
-    redirect_to jobs_path, notice: 'Job deleted'
+    # If the delete was triggered from the dashboard, return there; otherwise go to jobs list.
+    if params[:from] == 'dashboard' || (request.referer || '').include?('/dashboard')
+      redirect_to dashboard_path, notice: 'Job deleted'
+    else
+      redirect_to jobs_path, notice: 'Job deleted'
+    end
   end
 
   private

--- a/app/models/company.rb
+++ b/app/models/company.rb
@@ -1,3 +1,4 @@
 class Company < ApplicationRecord
     has_many :jobs, dependent: :destroy
+    validates :name, presence: true
 end

--- a/app/models/company.rb
+++ b/app/models/company.rb
@@ -1,4 +1,5 @@
 class Company < ApplicationRecord
     has_many :jobs, dependent: :destroy
     validates :name, presence: true
+    validates :website, presence: true
 end

--- a/app/views/companies/index.html.erb
+++ b/app/views/companies/index.html.erb
@@ -1,24 +1,29 @@
-<h1>Companies</h1>
+<div class="d-flex justify-content-between align-items-center mb-3">
+  <h1>Companies</h1>
+  <%= link_to 'New Company', new_company_path, class: 'btn btn-primary' %>
+</div>
 
-<%= link_to 'New Company', new_company_path, class: 'btn btn-primary' %>
-
-<table>
-  <thead>
-    <tr>
-      <th>Name</th>
-      <th>Website</th>
-      <th>Actions</th>
-    </tr>
-  </thead>
-  <tbody>
-    <% @companies.each do |company| %>
-      <tr>
-        <td><%= link_to company.name, company_path(company) %></td>
-        <td><%= company.website %></td>
-        <td>
-          <%= link_to 'Show', company_path(company) %>
-        </td>
-      </tr>
-    <% end %>
-  </tbody>
-</table>
+<div class="card">
+  <div class="card-body">
+    <table class="table table-striped">
+      <thead>
+        <tr>
+          <th>Name</th>
+          <th>Website</th>
+          <th>Actions</th>
+        </tr>
+      </thead>
+      <tbody>
+        <% @companies.each do |company| %>
+          <tr>
+            <td><%= link_to company.name, company_path(company) %></td>
+            <td><%= company.website %></td>
+            <td>
+              <%= link_to 'Show', company_path(company), class: 'btn btn-link p-0' %>
+            </td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  </div>
+</div>

--- a/app/views/companies/new.html.erb
+++ b/app/views/companies/new.html.erb
@@ -14,12 +14,12 @@
 
   <div class="field">
     <%= form.label :name %>
-    <%= form.text_field :name %>
+    <%= form.text_field :name, required: true, autofocus: true %>
   </div>
 
   <div class="field">
     <%= form.label :website %>
-    <%= form.text_field :website %>
+    <%= form.text_field :website, required: true %>
   </div>
 
   <div class="actions">

--- a/app/views/companies/new.html.erb
+++ b/app/views/companies/new.html.erb
@@ -24,7 +24,13 @@
 
   <div class="actions">
     <%= form.submit %>
+    <%# Preserve return_to so the create action can redirect back to new_job_path %>
+    <%= hidden_field_tag :return_to, params[:return_to] if params[:return_to].present? %>
   </div>
 <% end %>
 
-<%= link_to 'Back', companies_path %>
+<%= if params[:return_to] == 'jobs_new'
+      link_to 'Back', new_job_path
+    else
+      link_to 'Back', companies_path
+    end %>

--- a/app/views/companies/new.html.erb
+++ b/app/views/companies/new.html.erb
@@ -1,36 +1,39 @@
 <h1>New Company</h1>
 
-<%= form_with model: @company, local: true do |form| %>
-  <% if @company.errors.any? %>
-    <div id="error_explanation">
-      <h2><%= pluralize(@company.errors.count, "error") %> prohibited this company from being saved:</h2>
-      <ul>
-        <% @company.errors.full_messages.each do |message| %>
-          <li><%= message %></li>
-        <% end %>
-      </ul>
-    </div>
-  <% end %>
+<div class="card mb-3">
+  <div class="card-body">
+    <%= form_with model: @company, local: true do |form| %>
+      <% if @company.errors.any? %>
+        <div class="alert alert-danger">
+          <h4 class="alert-heading"><%= pluralize(@company.errors.count, "error") %> prevented this company from being saved:</h4>
+          <ul class="mb-0">
+            <% @company.errors.full_messages.each do |message| %>
+              <li><%= message %></li>
+            <% end %>
+          </ul>
+        </div>
+      <% end %>
 
-  <div class="field">
-    <%= form.label :name %>
-    <%= form.text_field :name, required: true, autofocus: true %>
+      <div class="mb-3">
+        <%= form.label :name, class: 'form-label' %>
+        <%= form.text_field :name, required: true, autofocus: true, class: 'form-control' %>
+      </div>
+
+      <div class="mb-3">
+        <%= form.label :website, class: 'form-label' %>
+        <%= form.text_field :website, required: true, class: 'form-control' %>
+      </div>
+
+      <div class="d-flex align-items-center">
+        <%= form.submit 'Create Company', class: 'btn btn-primary' %>
+        <%# Preserve return_to so the create action can redirect back to new_job_path %>
+        <%= hidden_field_tag :return_to, params[:return_to] if params[:return_to].present? %>
+        <%= if params[:return_to] == 'jobs_new'
+              link_to 'Back', new_job_path, class: 'btn btn-secondary ms-2'
+            else
+              link_to 'Back', companies_path, class: 'btn btn-secondary ms-2'
+            end %>
+      </div>
+    <% end %>
   </div>
-
-  <div class="field">
-    <%= form.label :website %>
-    <%= form.text_field :website, required: true %>
-  </div>
-
-  <div class="actions">
-    <%= form.submit %>
-    <%# Preserve return_to so the create action can redirect back to new_job_path %>
-    <%= hidden_field_tag :return_to, params[:return_to] if params[:return_to].present? %>
-  </div>
-<% end %>
-
-<%= if params[:return_to] == 'jobs_new'
-      link_to 'Back', new_job_path
-    else
-      link_to 'Back', companies_path
-    end %>
+</div>

--- a/app/views/companies/show.html.erb
+++ b/app/views/companies/show.html.erb
@@ -1,31 +1,36 @@
-<h1><%= @company.name %></h1>
+<div class="d-flex justify-content-between align-items-center mb-3">
+  <h1 class="mb-0"><%= @company.name %></h1>
+  <%= link_to 'Back to Companies', companies_path, class: 'btn btn-secondary' %>
+</div>
 
 <p><strong>Website:</strong> <%= @company.website %></p>
 
 <h2>Jobs at this Company</h2>
 <% if @jobs.any? %>
-  <table>
-    <thead>
-      <tr>
-        <th>Title</th>
-        <th>Status</th>
-        <th>Deadline</th>
-        <th>Actions</th>
-      </tr>
-    </thead>
-    <tbody>
-      <% @jobs.each do |job| %>
-        <tr>
-          <td><%= link_to job.title, job_path(job) %></td>
-          <td><%= job.status %></td>
-          <td><%= job.deadline %></td>
-          <td><%= link_to 'Show', job_path(job) %></td>
-        </tr>
-      <% end %>
-    </tbody>
-  </table>
+  <div class="card">
+    <div class="card-body">
+      <table class="table table-striped">
+        <thead>
+          <tr>
+            <th>Title</th>
+            <th>Status</th>
+            <th>Deadline</th>
+            <th>Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          <% @jobs.each do |job| %>
+            <tr>
+              <td><%= link_to job.title, job_path(job) %></td>
+              <td><%= job.status %></td>
+              <td><%= job.deadline %></td>
+              <td><%= link_to 'Show', job_path(job), class: 'btn btn-link p-0' %></td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
+  </div>
 <% else %>
   <p>No jobs found for this company.</p>
 <% end %>
-
-<%= link_to 'Back to Companies', companies_path %>

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -74,19 +74,21 @@
 <% if @jobs.empty? %>
   <p class="text-center">You have no job applications yet. Click the button above to add one!</p>
 <% else %>
-  <table class="table table-striped" id="dashboard-jobs-table">
-    <thead>
-      <tr>
-        <th>Title</th>
-        <th>Company</th>
-        <th>Status</th>
-        <th>Deadline</th>
-        <th>Actions</th>
-      </tr>
-    </thead>
-    <tbody>
-      <%= render partial: 'jobs/rows', locals: { jobs: @jobs } %>
-    </tbody>
-  </table>
+  <div class="table-responsive">
+    <table class="table table-striped" id="dashboard-jobs-table">
+      <thead>
+        <tr>
+          <th>Title</th>
+          <th>Company</th>
+          <th>Status</th>
+          <th>Deadline</th>
+          <th>Actions</th>
+        </tr>
+      </thead>
+      <tbody>
+        <%= render partial: 'jobs/rows', locals: { jobs: @jobs } %>
+      </tbody>
+    </table>
+  </div>
 <% end %>
 

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -85,8 +85,8 @@
           <th>Actions</th>
         </tr>
       </thead>
-      <tbody>
-        <%= render partial: 'jobs/rows', locals: { jobs: @jobs } %>
+        <tbody>
+        <%= render partial: 'jobs/rows', locals: { jobs: @jobs, from: 'dashboard' } %>
       </tbody>
     </table>
   </div>

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -13,7 +13,7 @@
             <div class="card mb-3 job-card applied">
               <div class="card-body">
                 <h5><%= job.title %></h5>
-                <p><strong>Company:</strong> <%= job.company&.name %></p>
+                <p><strong>Company:</strong> <%= job.company ? link_to(job.company.name, company_path(job.company)) : '' %></p>
               </div>
             </div>
           <% end %>
@@ -25,7 +25,7 @@
             <div class="card mb-3 job-card interview">
               <div class="card-body">
                 <h5><%= job.title %></h5>
-                <p><strong>Company:</strong> <%= job.company&.name %></p>
+                <p><strong>Company:</strong> <%= job.company ? link_to(job.company.name, company_path(job.company)) : '' %></p>
               </div>
             </div>
           <% end %>
@@ -37,7 +37,7 @@
             <div class="card mb-3 job-card offer">
               <div class="card-body">
                 <h5><%= job.title %></h5>
-                <p><strong>Company:</strong> <%= job.company&.name %></p>
+                <p><strong>Company:</strong> <%= job.company ? link_to(job.company.name, company_path(job.company)) : '' %></p>
               </div>
             </div>
           <% end %>
@@ -49,7 +49,7 @@
             <div class="card mb-3 job-card rejected">
               <div class="card-body">
                 <h5><%= job.title %></h5>
-                <p><strong>Company:</strong> <%= job.company&.name %></p>
+                <p><strong>Company:</strong> <%= job.company ? link_to(job.company.name, company_path(job.company)) : '' %></p>
               </div>
             </div>
           <% end %>

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -71,18 +71,22 @@
   </div>
 </div>
 
-<table id="dashboard-jobs-table">
-  <thead>
-    <tr>
-      <th>Title</th>
-      <th>Company</th>
-      <th>Status</th>
-      <th>Deadline</th>
-      <th>Actions</th>
-    </tr>
-  </thead>
-  <tbody>
-    <%= render partial: 'jobs/rows', locals: { jobs: @jobs } %>
-  </tbody>
-</table>
+<% if @jobs.empty? %>
+  <p class="text-center">You have no job applications yet. Click the button above to add one!</p>
+<% else %>
+  <table class="table table-striped" id="dashboard-jobs-table">
+    <thead>
+      <tr>
+        <th>Title</th>
+        <th>Company</th>
+        <th>Status</th>
+        <th>Deadline</th>
+        <th>Actions</th>
+      </tr>
+    </thead>
+    <tbody>
+      <%= render partial: 'jobs/rows', locals: { jobs: @jobs } %>
+    </tbody>
+  </table>
+<% end %>
 

--- a/app/views/jobs/_form.html.erb
+++ b/app/views/jobs/_form.html.erb
@@ -19,7 +19,7 @@
     <%= form.label :company_id, "Company" %>
     <%= form.collection_select :company_id, Company.all, :id, :name, prompt: "Select Company" %>
     <br>
-    <%= link_to 'Add New Company', new_company_path, target: '_blank', class: 'btn btn-link' %>
+  <%= link_to 'Add New Company', new_company_path(return_to: 'jobs_new'), class: 'btn btn-link' %>
   </div>
 
 

--- a/app/views/jobs/_form.html.erb
+++ b/app/views/jobs/_form.html.erb
@@ -1,8 +1,8 @@
 <%= form_with model: job, local: true do |form| %>
   <% if job.errors.any? %>
-    <div id="error_explanation">
-      <h2><%= pluralize(job.errors.count, "error") %> prohibited this job from being saved:</h2>
-      <ul>
+    <div class="alert alert-danger">
+      <h4 class="alert-heading"><%= pluralize(job.errors.count, "error") %> prevented this job from being saved:</h4>
+      <ul class="mb-0">
         <% job.errors.full_messages.each do |message| %>
           <li><%= message %></li>
         <% end %>
@@ -10,46 +10,51 @@
     </div>
   <% end %>
 
-  <div class="field">
-    <%= form.label :title %>
-    <%= form.text_field :title %>
-  </div>
+  <div class="card mb-3">
+    <div class="card-body">
+      <div class="mb-3">
+        <%= form.label :title, class: 'form-label' %>
+        <%= form.text_field :title, class: 'form-control' %>
+      </div>
 
-  <div class="field">
-    <%= form.label :company_id, "Company" %>
-    <%= form.collection_select :company_id, Company.all, :id, :name, prompt: "Select Company" %>
-    <br>
-  <%= link_to 'Add New Company', new_company_path(return_to: 'jobs_new'), class: 'btn btn-link' %>
-  </div>
+      <div class="mb-3">
+        <%= form.label :company_id, 'Company', class: 'form-label' %>
+        <%= form.collection_select :company_id, Company.all, :id, :name, { prompt: 'Select Company' }, { class: 'form-select' } %>
+        <div class="mt-2">
+          <%= link_to 'Add New Company', new_company_path(return_to: 'jobs_new'), class: 'btn btn-link p-0' %>
+        </div>
+      </div>
 
+      <div class="mb-3">
+        <%= form.label :link, class: 'form-label' %>
+        <%= form.url_field :link, class: 'form-control' %>
+      </div>
 
+      <div class="row">
+        <div class="col-md-6 mb-3">
+          <%= form.label :deadline, class: 'form-label' %>
+          <%= form.date_field :deadline, class: 'form-control' %>
+        </div>
+        <div class="col-md-6 mb-3">
+          <%= form.label :status, class: 'form-label' %>
+          <%= form.select :status, options_for_select([
+            ['Applied', 'applied'],
+            ['Interview Scheduled', 'interview'],
+            ['Rejected', 'rejected'],
+            ['Offer Received', 'offer']
+          ], job.status), { prompt: 'Select Status' }, { class: 'form-select' } %>
+        </div>
+      </div>
 
-  <div class="field">
-    <%= form.label :link %>
-    <%= form.url_field :link %>
-  </div>
+      <div class="mb-3">
+        <%= form.label :notes, class: 'form-label' %>
+        <%= form.text_area :notes, rows: 4, class: 'form-control' %>
+      </div>
 
-  <div class="field">
-    <%= form.label :deadline %>
-    <%= form.date_field :deadline %>
-  </div>
-
-  <div class="field">
-    <%= form.label :status %>
-    <%= form.select :status, options_for_select([
-      ['Applied', 'applied'],
-      ['Interview Scheduled', 'interview'],
-      ['Rejected', 'rejected'],
-      ['Offer Received', 'offer']
-    ], job.status), { prompt: 'Select Status' } %>
-  </div>
-
-  <div class="field">
-    <%= form.label :notes %>
-    <%= form.text_area :notes, rows: 4 %>
-  </div>
-
-  <div class="actions">
-    <%= form.submit %>
+      <div class="d-flex align-items-center">
+        <%= form.submit class: 'btn btn-primary' %>
+        <%= link_to 'Back', dashboard_path, class: 'btn btn-secondary ms-2' %>
+      </div>
+    </div>
   </div>
 <% end %>

--- a/app/views/jobs/_rows.html.erb
+++ b/app/views/jobs/_rows.html.erb
@@ -1,7 +1,7 @@
 <% (jobs || []).each do |job| %>
   <tr>
     <td><%= link_to job.title, job_path(job) %></td>
-    <td><%= job.company&.name %></td>
+  <td><%= job.company ? link_to(job.company.name, company_path(job.company)) : '' %></td>
     <td><%= job.status %></td>
     <td><%= job.deadline %></td>
     <td>

--- a/app/views/jobs/_rows.html.erb
+++ b/app/views/jobs/_rows.html.erb
@@ -1,6 +1,13 @@
 <% (jobs || []).each do |job| %>
   <tr>
-    <td><%= link_to job.title, job_path(job) %></td>
+    <%# If a 'from' local was passed (e.g. from: 'dashboard'), include it in the job link so the show page can decide where Back should go %>
+    <td>
+      <% if local_assigns[:from].present? %>
+        <%= link_to job.title, job_path(job, from: local_assigns[:from]) %>
+      <% else %>
+        <%= link_to job.title, job_path(job) %>
+      <% end %>
+    </td>
   <td><%= job.company ? link_to(job.company.name, company_path(job.company)) : '' %></td>
     <td><%= job.status %></td>
     <td><%= job.deadline %></td>

--- a/app/views/jobs/edit.html.erb
+++ b/app/views/jobs/edit.html.erb
@@ -3,4 +3,4 @@
 <%= render 'form', job: @job %>
 
 <%= link_to 'Show', @job %> |
-<%= link_to 'Back', jobs_path %>
+<%= link_to 'Back', dashboard_path %>

--- a/app/views/jobs/new.html.erb
+++ b/app/views/jobs/new.html.erb
@@ -2,4 +2,4 @@
 
 <%= render 'form', job: @job %>
 
-<%= link_to 'Back', jobs_path %>
+<%= link_to 'Back', dashboard_path %>

--- a/app/views/jobs/show.html.erb
+++ b/app/views/jobs/show.html.erb
@@ -1,11 +1,20 @@
-<h1><%= @job.title %></h1>
+<div class="card">
+	<div class="card-body">
+		<h1><%= @job.title %></h1>
 
-<p><strong>Company:</strong> <%= @job.company&.name %></p>
-<p><strong>Status:</strong> <%= @job.status %></p>
-<p><strong>Link:</strong> <%= link_to @job.link, @job.link if @job.link.present? %></p>
-<p><strong>Deadline:</strong> <%= @job.deadline %></p>
-<p><strong>Notes:</strong></p>
-<p><%= simple_format(@job.notes) if @job.notes.present? %></p>
+		<p><strong>Company:</strong> <%= @job.company&.name %></p>
+		<p><strong>Status:</strong> <%= @job.status %></p>
+		<p><strong>Link:</strong> <%= link_to @job.link, @job.link if @job.link.present? %></p>
+		<p><strong>Deadline:</strong> <%= @job.deadline %></p>
+		<p><strong>Notes:</strong></p>
+		<p><%= simple_format(@job.notes) if @job.notes.present? %></p>
 
-<%= link_to 'Edit', edit_job_path(@job) %> |
-<%= link_to 'Back', jobs_path %>
+		<%= link_to 'Edit', edit_job_path(@job) %> |
+		<%# Back should return to dashboard when we came from there (preserve via params or referer) %>
+		<% if params[:from] == 'dashboard' || request.referer&.include?('/dashboard') %>
+			<%= link_to 'Back', dashboard_path %>
+		<% else %>
+			<%= link_to 'Back', jobs_path %>
+		<% end %>
+	</div>
+</div>

--- a/features/company_from_job.feature
+++ b/features/company_from_job.feature
@@ -1,0 +1,15 @@
+Feature: Create company from job form
+  As a user creating a job
+  I want to be able to add a new company and return to the job form
+
+  Background:
+    Given a user exists with email "company_user@example.com"
+    And I am signed in as "company_user@example.com"
+
+  Scenario: Create company from job form and return
+    When I visit the new job page
+    And I click the Add New Company link
+    Then I should be on the new company page
+    When I fill in the new company form with name "NewCo" and website "https://newco.example"
+    And I submit the company form
+    Then I should be back on the new job page

--- a/features/dashboard_navigation.feature
+++ b/features/dashboard_navigation.feature
@@ -1,0 +1,15 @@
+Feature: Dashboard navigation
+  As a signed-in user
+  I want Back to return me to the dashboard after opening a job from there
+
+  Background:
+    Given a user exists with email "dash_user@example.com"
+    And I am signed in as "dash_user@example.com"
+
+  Scenario: Open job from dashboard and go back
+    Given a job exists titled "BackJob" for company "DashCo"
+    When I visit the dashboard
+    And I click the job titled "BackJob"
+    Then I should be on the job details page for "BackJob"
+    When I click "Back"
+    Then I should be on the dashboard

--- a/features/jobs.feature
+++ b/features/jobs.feature
@@ -1,0 +1,31 @@
+Feature: Job management
+  In order to manage my applications
+  As a signed-in user
+  I want to create, view, edit and delete job applications
+
+  Background:
+    Given a user exists with email "cuke_user@example.com"
+    And I am signed in as "cuke_user@example.com"
+
+  Scenario: Create a job
+    Given a company exists with name "CukeCo"
+    When I visit the new job page
+    And I fill in the new job form with title "CukeJob", company "CukeCo"
+    And I submit the job form
+    Then I should see a job titled "CukeJob" on the jobs list
+
+  Scenario: Edit a job
+    Given a company exists with name "EditCo"
+    And a job exists titled "OldTitle" for company "EditCo"
+    When I visit the jobs list
+    And I click Edit for the job titled "OldTitle"
+    And I change the job title to "NewTitle"
+    And I submit the job form
+    Then I should see a job titled "NewTitle" on the jobs list
+
+  Scenario: Delete a job
+    Given a company exists with name "DelCo"
+    And a job exists titled "ToDelete" for company "DelCo"
+    When I visit the jobs list
+    And I delete the job titled "ToDelete"
+    Then I should not see a job titled "ToDelete" on the jobs list

--- a/features/search.feature
+++ b/features/search.feature
@@ -1,0 +1,15 @@
+Feature: Job search
+  As a signed-in user
+  I want to filter jobs in the dashboard using the search bar
+
+  Background:
+    Given a user exists with email "search_user@example.com"
+    And I am signed in as "search_user@example.com"
+    And a company exists with name "SearchCo"
+    And a job exists titled "FindMe" for company "SearchCo"
+    And a job exists titled "Other" for company "SearchCo"
+
+  Scenario: Search filters jobs (server-side)
+    When I visit the dashboard with query "FindMe"
+    Then I should see a job titled "FindMe"
+    And I should not see a job titled "Other"

--- a/features/step_definitions/jobs_steps.rb
+++ b/features/step_definitions/jobs_steps.rb
@@ -1,0 +1,151 @@
+Given('a user exists with email {string}') do |email|
+  User.create!(email: email, password: 'Password1!', password_confirmation: 'Password1!', full_name: 'Cuke', phone: '+10000000000')
+end
+
+Given('I am signed in as {string}') do |email|
+  user = User.find_by(email: email)
+  login_as(user, scope: :user)
+end
+
+Given('a company exists with name {string}') do |name|
+  Company.create!(name: name, website: "https://#{name.downcase}.example")
+end
+
+Given('a job exists titled {string} for company {string}') do |title, company_name|
+  user = User.first || User.create!(email: 'tmp@example.com', password: 'Password1!', password_confirmation: 'Password1!', full_name: 'Tmp', phone: '+10000000001')
+  company = Company.find_by(name: company_name) || Company.create!(name: company_name, website: "https://#{company_name.downcase}.example")
+  Job.create!(title: title, user: user, company: company)
+end
+
+When('I visit the new job page') do
+  visit new_job_path
+end
+
+When('I fill in the new job form with title {string}, company {string}') do |title, company_name|
+  select company_name, from: 'job[company_id]'
+  fill_in 'job[title]', with: title
+end
+
+When('I submit the job form') do
+  # target the job form specifically (new_job or edit_job) to avoid ambiguous matches
+  # prefer the form that contains the job title field to avoid ambiguous matches
+  if has_selector?('form input[name="job[title]"]')
+    within(:xpath, "//form[.//input[@name='job[title]']]") do
+      first('input[type="submit"], button[type="submit"]').click
+    end
+  elsif has_selector?('form#new_job')
+    within('form#new_job') { first('input[type="submit"], button[type="submit"]').click }
+  elsif has_selector?('form#edit_job')
+    within('form#edit_job') { first('input[type="submit"], button[type="submit"]').click }
+  else
+    within('form') { first('input[type="submit"], button[type="submit"]').click }
+  end
+end
+
+Then('I should see a job titled {string} on the jobs list') do |title|
+  visit jobs_path
+  expect(page).to have_content(title)
+end
+
+When('I visit the jobs list') do
+  visit jobs_path
+end
+
+When('I click Edit for the job titled {string}') do |title|
+  within(:xpath, "//tr[td[contains(., '#{title}')]]") do
+    click_link 'Edit'
+  end
+end
+
+When('I change the job title to {string}') do |new_title|
+  fill_in 'job[title]', with: new_title
+end
+
+When('I delete the job titled {string}') do |title|
+  within(:xpath, "//tr[td[contains(., '#{title}')]]") do
+    # button_to may render input or button; try both
+    if has_selector?('input[type="submit"][value="Delete"]')
+      find('input[type="submit"][value="Delete"]').click
+    elsif has_selector?('button', text: 'Delete')
+      find('button', text: 'Delete').click
+    else
+      # fallback to link
+      click_link 'Delete'
+    end
+  end
+end
+
+Then('I should not see a job titled {string} on the jobs list') do |title|
+  visit jobs_path
+  expect(page).not_to have_content(title)
+end
+
+When('I click the Add New Company link') do
+  click_link 'Add New Company'
+end
+
+Then('I should be on the new company page') do
+  # ignore query params like return_to
+  expect(URI.parse(page.current_url).path).to eq(new_company_path)
+end
+
+When('I fill in the new company form with name {string} and website {string}') do |name, website|
+  fill_in 'company[name]', with: name
+  fill_in 'company[website]', with: website
+end
+
+When('I submit the company form') do
+  click_button 'Create Company'
+end
+
+Then('I should be back on the new job page') do
+  expect(URI.parse(page.current_url).path).to eq(new_job_path)
+end
+
+When('I visit the dashboard') do
+  visit dashboard_path
+end
+
+When('I visit the dashboard with query {string}') do |q|
+  visit dashboard_path(q: q)
+end
+
+When('I click the job titled {string}') do |title|
+  within(:xpath, "//tr[td[contains(., '#{title}')]]") do
+    click_link title
+  end
+end
+
+Then('I should be on the job details page for {string}') do |title|
+  job = Job.find_by(title: title)
+  expect(URI.parse(page.current_url).path).to eq(job_path(job))
+end
+
+When('I click {string}') do |text|
+  click_link text
+end
+
+When('I fill in the search input with {string}') do |query|
+  # the dashboard search uses data-job-search-target or placeholder
+  if has_selector?('input[data-job-search-target="input"]')
+    find('input[data-job-search-target="input"]').set(query)
+  else
+    fill_in 'Search jobs by title or company...', with: query
+  end
+end
+
+When('I press Search') do
+  click_button 'Search'
+end
+
+Then('I should see a job titled {string}') do |title|
+  expect(page).to have_content(title)
+end
+
+Then('I should not see a job titled {string}') do |title|
+  expect(page).not_to have_content(title)
+end
+
+Then('I should be on the dashboard') do
+  expect(URI.parse(page.current_url).path).to eq(dashboard_path)
+end

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -51,3 +51,12 @@ end
 # The :transaction strategy is faster, but might give you threading problems.
 # See https://github.com/cucumber/cucumber-rails/blob/master/features/choose_javascript_database_strategy.feature
 Cucumber::Rails::Database.javascript_strategy = :truncation
+
+# Enable Warden test helpers so scenarios can sign in without UI steps
+require 'warden'
+World(Warden::Test::Helpers)
+Warden.test_mode!
+
+After do
+  Warden.test_reset!
+end

--- a/spec/models/company_spec.rb
+++ b/spec/models/company_spec.rb
@@ -1,5 +1,16 @@
 require 'rails_helper'
 
 RSpec.describe Company, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  it 'is invalid without a name' do
+    company = Company.new(name: nil, website: 'https://example.com')
+    expect(company).not_to be_valid
+    expect(company.errors[:name]).to include("can't be blank")
+  end
+
+  it 'is invalid without a website' do
+    company = Company.new(name: 'NoWeb', website: nil)
+    expect(company).not_to be_valid
+    expect(company.errors[:website]).to include("can't be blank")
+  end
+
 end

--- a/spec/models/job_spec.rb
+++ b/spec/models/job_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe Job, type: :model do
   let(:user) { User.create!(email: 'jj@example.com', password: 'Password1!', password_confirmation: 'Password1!', full_name: 'J', phone: '+12345678901') }
-  let(:company) { Company.create!(name: 'Comp') }
+  let(:company) { Company.create!(name: 'Comp', website: 'https://comp.example') }
 
   it 'is valid with title, user and company' do
     job = Job.new(title: 'X', user: user, company: company)

--- a/spec/requests/jobs_crud_spec.rb
+++ b/spec/requests/jobs_crud_spec.rb
@@ -13,8 +13,8 @@ RSpec.describe 'Jobs CRUD', type: :request do
   end
 
   it 'creates a job with valid attributes' do
-    post jobs_path, params: { job: { title: 'CreateMe', user_id: user.id, company_id: company.id } }
-    expect(response).to redirect_to(jobs_path)
+  post jobs_path, params: { job: { title: 'CreateMe', user_id: user.id, company_id: company.id } }
+  expect(response).to redirect_to(dashboard_path)
     expect(Job.find_by(title: 'CreateMe')).not_to be_nil
   end
 
@@ -51,15 +51,15 @@ RSpec.describe 'Jobs CRUD', type: :request do
 
   it 'updates a job' do
     job = Job.create!(title: 'Old', user: user, company: company)
-    patch job_path(job), params: { job: { title: 'Updated' } }
-    expect(response).to redirect_to(jobs_path)
+  patch job_path(job), params: { job: { title: 'Updated' }, from: 'dashboard' }
+  expect(response).to redirect_to(dashboard_path)
     expect(job.reload.title).to eq('Updated')
   end
 
   it 'deletes a job' do
     job = Job.create!(title: 'Bye', user: user, company: company)
-    delete job_path(job)
-    expect(response).to redirect_to(jobs_path)
+  delete job_path(job), params: { from: 'dashboard' }
+  expect(response).to redirect_to(dashboard_path)
     expect(Job.find_by(id: job.id)).to be_nil
   end
 end

--- a/spec/requests/jobs_crud_spec.rb
+++ b/spec/requests/jobs_crud_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe 'Jobs CRUD', type: :request do
   let!(:user) { User.create!(email: 'u@example.com', password: 'Password1!', password_confirmation: 'Password1!', full_name: 'U', phone: '+12345678901') }
-  let!(:company) { Company.create!(name: 'TestCo') }
+  let!(:company) { Company.create!(name: 'TestCo', website: 'https://testco.example') }
   before { login_as(user, scope: :user) }
 
   it 'lists jobs' do

--- a/spec/system/company_from_job_spec.rb
+++ b/spec/system/company_from_job_spec.rb
@@ -19,8 +19,9 @@ RSpec.describe 'Create company from job form', type: :system do
 
     expect(page).to have_current_path(new_company_path(return_to: 'jobs_new'))
 
-    fill_in 'Name', with: 'SystemCo'
-    click_button 'Create'
+  fill_in 'Name', with: 'SystemCo'
+  fill_in 'Website', with: 'https://systemco.example'
+  click_button 'Create Company'
 
     # After creating, we should be back on the job form
     expect(page).to have_current_path(new_job_path)
@@ -33,9 +34,9 @@ RSpec.describe 'Create company from job form', type: :system do
   it 'shows validation errors when creating a company with blank name and stays on companies/new' do
     visit new_company_path(return_to: 'jobs_new')
     fill_in 'Name', with: ''
-    click_button 'Create'
+  click_button 'Create Company'
 
-  # On validation failure the form will re-render; ensure we remain on the new company form
+  # On validation failure the form will re-render; ensure we see the validation message
   expect(page).to have_content("prohibited this company from being saved")
   end
 end

--- a/spec/system/company_from_job_spec.rb
+++ b/spec/system/company_from_job_spec.rb
@@ -1,0 +1,41 @@
+require 'rails_helper'
+
+RSpec.describe 'Create company from job form', type: :system do
+  before do
+    driven_by :rack_test
+  end
+
+  let!(:user) { User.create!(email: 'u2@example.com', password: 'Password1!', password_confirmation: 'Password1!', full_name: 'U2', phone: '+12345678902') }
+
+  before { login_as(user, scope: :user) }
+
+  it 'creates a company from the job form and returns to the job form' do
+    visit new_job_path
+
+    expect(page).to have_current_path(new_job_path)
+
+    # Click the Add New Company link which should include the return_to param
+    click_link 'Add New Company'
+
+    expect(page).to have_current_path(new_company_path(return_to: 'jobs_new'))
+
+    fill_in 'Name', with: 'SystemCo'
+    click_button 'Create'
+
+    # After creating, we should be back on the job form
+    expect(page).to have_current_path(new_job_path)
+
+  # The company select should include the newly created company
+  expect(page).to have_select('Company')
+  expect(find_field('Company').all('option').map(&:text)).to include('SystemCo')
+  end
+
+  it 'shows validation errors when creating a company with blank name and stays on companies/new' do
+    visit new_company_path(return_to: 'jobs_new')
+    fill_in 'Name', with: ''
+    click_button 'Create'
+
+  # On validation failure the form will re-render; ensure we remain on the new company form
+  expect(page).to have_content("prohibited this company from being saved")
+  end
+end

--- a/spec/system/company_from_job_spec.rb
+++ b/spec/system/company_from_job_spec.rb
@@ -33,10 +33,11 @@ RSpec.describe 'Create company from job form', type: :system do
 
   it 'shows validation errors when creating a company with blank name and stays on companies/new' do
     visit new_company_path(return_to: 'jobs_new')
-    fill_in 'Name', with: ''
-  click_button 'Create Company'
-
-  # On validation failure the form will re-render; ensure we see the validation message
-  expect(page).to have_content("prohibited this company from being saved")
+    within('.card') do
+      fill_in 'Name', with: ''
+      click_button 'Create Company'
+      # On validation failure the form will re-render; ensure we see the validation errors
+      expect(page).to have_content("can't be blank")
+    end
   end
 end

--- a/spec/system/dashboard_edit_back_spec.rb
+++ b/spec/system/dashboard_edit_back_spec.rb
@@ -21,7 +21,9 @@ RSpec.describe 'Dashboard edit/back behavior', type: :system do
 
     expect(page).to have_current_path(edit_job_path(job))
 
-    click_link 'Back'
+    within('.card') do
+      click_link 'Back'
+    end
 
     expect(page).to have_current_path(dashboard_path)
   end

--- a/spec/system/dashboard_edit_back_spec.rb
+++ b/spec/system/dashboard_edit_back_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'Dashboard edit/back behavior', type: :system do
   end
 
   let!(:user) { User.create!(email: 'u3@example.com', password: 'Password1!', password_confirmation: 'Password1!', full_name: 'U3', phone: '+12345678903') }
-  let!(:company) { Company.create!(name: 'DashCo') }
+  let!(:company) { Company.create!(name: 'DashCo', website: 'https://dashco.example') }
   let!(:job) { Job.create!(title: 'DashJob', user: user, company: company) }
 
   before { login_as(user, scope: :user) }

--- a/spec/system/dashboard_edit_back_spec.rb
+++ b/spec/system/dashboard_edit_back_spec.rb
@@ -1,0 +1,28 @@
+require 'rails_helper'
+
+RSpec.describe 'Dashboard edit/back behavior', type: :system do
+  before do
+    driven_by :rack_test
+  end
+
+  let!(:user) { User.create!(email: 'u3@example.com', password: 'Password1!', password_confirmation: 'Password1!', full_name: 'U3', phone: '+12345678903') }
+  let!(:company) { Company.create!(name: 'DashCo') }
+  let!(:job) { Job.create!(title: 'DashJob', user: user, company: company) }
+
+  before { login_as(user, scope: :user) }
+
+  it 'returns to dashboard when clicking Back on the edit page' do
+    visit dashboard_path
+
+    # Click the Edit link for the job — there may be multiple buttons, find by link text near the job title
+    within(:xpath, "//tr[td[contains(., 'DashJob')]]") do
+      click_link 'Edit'
+    end
+
+    expect(page).to have_current_path(edit_job_path(job))
+
+    click_link 'Back'
+
+    expect(page).to have_current_path(dashboard_path)
+  end
+end

--- a/spec/system/job_show_back_from_dashboard_spec.rb
+++ b/spec/system/job_show_back_from_dashboard_spec.rb
@@ -1,0 +1,30 @@
+require 'rails_helper'
+
+RSpec.describe 'Job show back behavior', type: :system do
+  before do
+    driven_by :rack_test
+  end
+
+  let!(:user) { User.create!(email: 'u5@example.com', password: 'Password1!', password_confirmation: 'Password1!', full_name: 'U5', phone: '+12345678905') }
+  let!(:company) { Company.create!(name: 'BackCo', website: 'https://backco.example') }
+  let!(:job) { Job.create!(title: 'BackJob', user: user, company: company) }
+
+  before { login_as(user, scope: :user) }
+
+  it 'returns to dashboard when job was opened from dashboard and Back is clicked' do
+    visit dashboard_path
+
+    # Click the job title link in the dashboard table
+    within(:xpath, "//tr[td[contains(., 'BackJob')]]") do
+      click_link 'BackJob'
+    end
+
+  expect(page).to have_current_path(job_path(job, from: 'dashboard'))
+
+    within('.card') do
+      click_link 'Back'
+    end
+
+    expect(page).to have_current_path(dashboard_path)
+  end
+end

--- a/spec/system/new_job_back_spec.rb
+++ b/spec/system/new_job_back_spec.rb
@@ -11,7 +11,9 @@ RSpec.describe 'New Job Back button', type: :system do
   it 'returns to dashboard when clicking Back on the new job page' do
     visit new_job_path
     expect(page).to have_current_path(new_job_path)
-    click_link 'Back'
+    within('.card') do
+      click_link 'Back'
+    end
     expect(page).to have_current_path(dashboard_path)
   end
 end

--- a/spec/system/new_job_back_spec.rb
+++ b/spec/system/new_job_back_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+RSpec.describe 'New Job Back button', type: :system do
+  before do
+    driven_by :rack_test
+  end
+
+  let!(:user) { User.create!(email: 'u4@example.com', password: 'Password1!', password_confirmation: 'Password1!', full_name: 'U4', phone: '+12345678904') }
+  before { login_as(user, scope: :user) }
+
+  it 'returns to dashboard when clicking Back on the new job page' do
+    visit new_job_path
+    expect(page).to have_current_path(new_job_path)
+    click_link 'Back'
+    expect(page).to have_current_path(dashboard_path)
+  end
+end


### PR DESCRIPTION
List of redirect mistakes that need to be fixed to ensure smooth functionality:
1.After clicking create job, redirect to /dashboard instead of refreshing /jobs/new -DONE
2. on /dashboard, when under the table of job display, there should be a clickable link on the company name to show the company info , just like how it is on the job title. DONE
3. on /dashboard when you click 'edit' on a job application and then click 'back it should take you back to the dashboard, where the user can see the updated job entry - DONE
4.Fixed page footer element is concealing jobs display in /dashboard - DONE 
5. Add tests for these functionalities- DONE
6. When creating new company - handle nil values you can't create a company with empty fields. - DONE
7. When clicking 'back' in /jobs/new it should redirect to /dashboard.- DONE
8. Revamped UI for forms - DONE