### PR TITLE
Added rspec and cucumber tests and functionality for non-Js job search

### DIFF
--- a/app/controllers/jobs_controller.rb
+++ b/app/controllers/jobs_controller.rb
@@ -8,6 +8,13 @@ class JobsController < ApplicationController
     # sorting by column/direction, and support Turbo stream responses.
     @jobs = current_user.jobs.includes(:company)
 
+    # Server-side search fallback for non-JS clients: filter by q param
+    if params[:q].present?
+      q = "%#{params[:q].to_s.downcase}%"
+      # use left_joins so jobs without a company are included
+      @jobs = @jobs.left_joins(:company).where("LOWER(jobs.title) LIKE :q OR LOWER(companies.name) LIKE :q", q: q)
+    end
+
     sort = params[:sort]
     direction = params[:direction] == "desc" ? :desc : :asc
 

--- a/app/javascript/controllers/job_search_controller.js
+++ b/app/javascript/controllers/job_search_controller.js
@@ -10,6 +10,16 @@ export default class extends Controller {
     }
     console.debug('job-search controller connected')
     this.inputTarget.addEventListener("input", this.search.bind(this))
+
+    // If the input is inside a form, prevent normal submission when JS is enabled
+    const form = this.inputTarget.closest('form')
+    if (form) {
+      form.addEventListener('submit', (e) => {
+        // Prevent full-page submit and rely on client-side filtering
+        e.preventDefault()
+        this.search()
+      })
+    }
   }
 
   search() {

--- a/app/views/jobs/index.html.erb
+++ b/app/views/jobs/index.html.erb
@@ -7,21 +7,12 @@
   <hr>
 
   <div class="mb-3" data-controller="job-search">
-    <div class="input-group">
-      <input
-        type="text"
-        data-job-search-target="input"
-        class="form-control"
-        placeholder="Search jobs by title or company..."
-      >
-      <button
-        type="button"
-        data-action="click->job-search#search"
-        class="btn btn-primary"
-      >
-        Search
-      </button>
-    </div>
+    <%= form_with url: jobs_path, method: :get, local: true, html: { class: 'd-flex' } do |f| %>
+      <div class="input-group w-100">
+        <%= f.text_field :q, value: params[:q], placeholder: 'Search jobs by title or company...', class: 'form-control', data: { 'job-search-target': 'input' } %>
+        <%= f.submit 'Search', class: 'btn btn-primary', data: { action: 'job-search#search' } %>
+      </div>
+    <% end %>
   </div>
 
   <% if @jobs.any? %>

--- a/features/search.feature
+++ b/features/search.feature
@@ -14,3 +14,11 @@ Feature: Job search
     Then I should see the search input
     And I should see a job titled "FindMe"
     And I should see a job titled "Other"
+    Scenario: Search form submits and filters results (non-JS)
+      Given a job exists titled "FindMe" for company "SearchCo"
+      Given a job exists titled "Other" for company "SearchCo"
+      When I visit the jobs list
+      And I fill in the search input with "FindMe"
+      And I press Search
+      Then I should see a job titled "FindMe"
+      And I should not see a job titled "Other"

--- a/spec/requests/jobs_request_spec.rb
+++ b/spec/requests/jobs_request_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+RSpec.describe 'Jobs search (server-side)', type: :request do
+	let(:user) { User.create!(email: 'search@example.com', password: 'Password1!', password_confirmation: 'Password1!', full_name: 'Search User', phone: '+12345678902') }
+	let(:company) { Company.create!(name: 'SearchCo', website: 'https://searchco.example') }
+	before { login_as(user, scope: :user) }
+
+	it 'filters jobs by q param (title match)' do
+		Job.create!(title: 'FindMe', user: user, company: company)
+		Job.create!(title: 'Other', user: user, company: company)
+		get jobs_path, params: { q: 'FindMe' }
+		expect(response).to be_successful
+		expect(response.body).to include('FindMe')
+		expect(response.body).not_to include('Other')
+	end
+
+	it 'filters jobs by q param (matches job without company)' do
+			# Job requires a company in this app, so create with the test company.
+			Job.create!(title: 'SoloJob', user: user, company: company)
+			get jobs_path, params: { q: 'SoloJob' }
+		expect(response).to be_successful
+		expect(response.body).to include('SoloJob')
+	end
+end


### PR DESCRIPTION
Added a server-side fallback option for the job search in case javascript is disabled in the browser.

- The user would need to type the name and click on the search button to display results.
- To restore the view of all jobs, they would need to clear the search bar and click on the search button.